### PR TITLE
The error means COLLECT() can’t take a BUNDLE. I flipped the macOS bu…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
           if [ "${{ runner.os }}" = "macOS" ]; then
             ASSET="asm-debugger-macos-${TAG}.zip"
-            (cd dist/asm-debugger && zip -r "../../${ASSET}" asm-debugger.app)
+            zip -r "${ASSET}" dist/asm-debugger.app
           else
             ASSET="asm-debugger-linux-${TAG}.zip"
             zip -r "${ASSET}" dist/asm-debugger

--- a/asm-debugger.spec
+++ b/asm-debugger.spec
@@ -44,14 +44,7 @@ exe = EXE(
 )
 
 if sys.platform == "darwin":
-    app = BUNDLE(
-        exe,
-        name="asm-debugger.app",
-        icon=None,
-        bundle_identifier=None,
-    )
     coll = COLLECT(
-        app,
         exe,
         a.binaries,
         a.zipfiles,
@@ -60,6 +53,12 @@ if sys.platform == "darwin":
         upx=True,
         upx_exclude=[],
         name="asm-debugger",
+    )
+    app = BUNDLE(
+        coll,
+        name="asm-debugger.app",
+        icon=None,
+        bundle_identifier=None,
     )
 else:
     coll = COLLECT(


### PR DESCRIPTION
…ild flow so we COLLECT() first, then wrap that

  output in BUNDLE(), which matches PyInstaller’s macOS expectations. I also updated the macOS packaging path to zip
  dist/asm-debugger.app.